### PR TITLE
fixed typo in devtools::install_github() line

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can install advertools from github with:
 
 ``` r
 install.packages("devtools")
-devtools::install_github("eliasdabbas/advertools")
+devtools::install_github("eliasdabbas/radvertools")
 ```
 
 word\_frequency()


### PR DESCRIPTION
previous -> devtools::install_github("eliasdabbas/advertools")

adjusted -> devtools::install_github("eliasdabbas/radvertools")

Was missing 'r' before advertools